### PR TITLE
Use new terminus phar, rather than the deprecated drush extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Refresh the database on your local development environment from Pantheon and mak
 
 __Installation:__
  1. Clone into your ~/.drush folder.
- 2. Set a site UUID in sites/default/settings.local.php
-  * `$conf['caboose_pantheon_uuid'] = '44444444-3333-2222-1111-000000000000';`
+ 2. Set a site name in sites/default/settings.local.php
+  * `$conf['caboose_pantheon_name'] = 'my-site';`
  3. Clear Drush cache with ```drush cc drush``` command.
  4. Copy default.settings.inc as settings.inc to list modules to enable/disable.
  5. Copy default.sanitize.inc as sanitize.inc and adjust (recommended).
@@ -22,6 +22,6 @@ __Basic examples:__
 Default environment is live.
 
 __Notes:__
- * Be sure to login to Terminus via the ```drush pauth``` command.
- * If you haven't used other Terminus commands, you'll likely need to refresh aliases with the ```drush paliases`` command.
+ * Be sure you've installed [Terminus](https://github.com/pantheon-systems/cli/releases) (0.9.3 or greater is recommended)
+ * Be sure to login to Terminus via the ```terminus auth login``` command.
  * Progress indicator on mysql import requires [`pv`](http://www.ivarch.com/programs/pv.shtml) (`brew install pv`)

--- a/caboose.drush.inc
+++ b/caboose.drush.inc
@@ -101,40 +101,51 @@ function drush_caboose_fresh($env = DEFAULT_ENV) {
  * Run through freshening up steps.
  */
 function _caboose_install($env) {
+  $terminus = exec('which terminus');
+  $site_uuid = variable_get('caboose_pantheon_uuid', NULL);
+  $site_name = variable_get('caboose_pantheon_site', NULL);
 
   // Sanity checking.
-  if (!function_exists('terminus_drush_command')) {
+  if (empty($terminus)) {
     return drush_set_error('DRUSH_CABOOSE_NO_TERMINUS', 'Terminus not available.');
   }
-
-  if (variable_get('caboose_pantheon_uuid', FALSE)) {
-    $site_uuid = variable_get('caboose_pantheon_uuid', NULL);
-  }
-  else {
-    return drush_set_error('DRUSH_CABOOSE_NO_SITE', 'No site UUID specified.');
+  if (version_compare(phpversion(), '5.5') < 0) {
+    return drush_set_error('DRUSH_CABOOSE_PHP_55_MIN', 'Terminus requires PHP 5.5 at a minimum.');
   }
 
-  // Get the user's session set.
-  if ($session_data = terminus_bootstrap()) {
-    extract($session_data);
+  // Ensure we're logged in.
+  $exit_code = NULL;
+  $array = array();
+  exec($terminus . ' auth whoami', $array, $exit_code);
+  if ($exit_code !== 0) {
+    return drush_set_error('DRUSH_CABOOSE_NO_AUTH', 'Terminus is not authenticated with Pantheon.');
   }
-  else {
-    return FALSE;
+
+  // Backwards compatibility layer, load site name from given UUID if available.
+  if (empty($site_name) && !empty($site_uuid)) {
+    $sites_info = json_decode(exec($terminus . ' sites list --format=json'));
+    foreach ($sites_info as $site_info) {
+      if ($site_info->id === $site_uuid) {
+        $site_name = $site_info->name;
+        break;
+      }
+    }
   }
 
-  $target_site = '@self';
+  // If we still have no Pantheon site name, abort.
+  if (empty($site_name)) {
+    return drush_set_error('DRUSH_CABOOSE_NO_SITE', 'No site UUID or name specified.');
+  }
 
-  // Download and load code modified from drush_terminus_pantheon_site_load_backup().
-  // Retrieve the latest bucket.
-  $bucket = terminus_latest_bucket($site_uuid, $env, 'database');
-
+  // Determine the latest backup URL and download it to the drush tmp folder.
+  // terminus site backups get --site={$site_name} --env={$env} --element=db --latest --format=json
   drush_print('Downloading database from (' . $env . ') site backup.' . "\n");
   $destination = drush_tempdir();
-  $result = terminus_api_backup_download_url($site_uuid, $env, $bucket, 'database');
-  $data = json_decode($result['json']);
-  $filename = strstr(basename($data->url), '?', '_');
+  $raw_url = exec($terminus . ' site backups get --site=' . escapeshellarg($site_name) . ' --env=' . escapeshellarg($env) . ' --element=db --latest --format=json');
+  $url = json_decode($raw_url);
+  $filename = strstr(basename($url), '?', '_');
 
-  $path = _caboose_download_file($data->url, $destination . DIRECTORY_SEPARATOR . $filename, TRUE);
+  $path = _caboose_download_file($url, $destination . DIRECTORY_SEPARATOR . $filename, TRUE);
 
   if (!$path && !drush_get_context('DRUSH_SIMULATE')) {
     return drush_set_error('DRUSH_PSITE_DOWNLOAD_FAILED', 'Unable to download ' . $filename . ' to ' . $destination . ' from ' . $data->url);


### PR DESCRIPTION
## What? Why?
Pantheon will soon start making backwards incompatible API changes to services used by Terminus.  In order to avoid breaking workflows, we should migrate to using the next-gen Terminus CLI, rather than the drush extension.

This updates the mechanism used to get the latest backup URL to use the new CLI.

## Release Notes
- Requires the new CLI be installed and executable from the command line as `terminus`.
- Requires PHP CLI >= 5.5
- Maintains backward compatibility with `$conf['caboose_pantheon_uuid']`, but recommended that you replace with `$conf['caboose_pantheon_site']`.